### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/internal/controllers/admin/blog/ai_post_editor/templates/app.js
+++ b/internal/controllers/admin/blog/ai_post_editor/templates/app.js
@@ -48,7 +48,6 @@ const postEditorApp = {
         async regenerateSection(section) {
             // Set loading state for this section
             if (section.startsWith('section_')) {
-                const index = section.split('_')[1];
                 this.loadingSections[section] = true;
             } else {
                 this.loadingSections[section] = true;


### PR DESCRIPTION
The best fix is to remove the unused `index` declaration in the `if (section.startsWith('section_'))` block and keep behavior identical.

- **General approach:** delete dead variables that are not read.
- **Specific change:** in `internal/controllers/admin/blog/ai_post_editor/templates/app.js`, inside `async regenerateSection(section)`, remove `const index = section.split('_')[1];` from the loading-state setup block.
- **No functional change:** loading state still uses `this.loadingSections[section] = true;`, and the later index parsing at line 78 remains unchanged for actual section replacement.
- **No new imports/dependencies/methods** are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._