### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/internal/resources/js/blockarea_v0200.js
+++ b/internal/resources/js/blockarea_v0200.js
@@ -156,7 +156,6 @@ var BlockAreaText = {
 };
 
 function BlockArea(blockAreaId) {
-  var self = this;
   var blockAreaId = blockAreaId;
   var blocks = [];
   var blockDefinitions = [];


### PR DESCRIPTION
The fix is to remove the unused local variable declaration inside `BlockArea`:

- File: `internal/resources/js/blockarea_v0200.js`
- Region: function `BlockArea(blockAreaId)` near lines 158–161.
- Change: delete `var self = this;`.
- No imports, helper methods, or dependency changes are needed.
- Functionality remains unchanged because the variable is never read.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._