### PR TITLE
Fix for Comparison of identical values

### DIFF
--- a/internal/controllers/user/partials/user_quick_links.go
+++ b/internal/controllers/user/partials/user_quick_links.go
@@ -15,11 +15,6 @@ type UserQuickLinksOptions struct {
 
 func UserQuickLinks(req *http.Request, opts ...UserQuickLinksOptions) *hb.Tag {
 	opt := lo.FirstOr(opts, UserQuickLinksOptions{})
-	errorMessage := ""
-
-	if errorMessage != "" {
-		return hb.Section().Text(errorMessage)
-	}
 
 	cardsData := []struct {
 		Title              string


### PR DESCRIPTION
The best fix is to remove the ineffective `errorMessage` placeholder and its always-false conditional block, since no error value is ever set in the shown function. This preserves current behavior (the branch never executed anyway) while eliminating dead/redundant logic that static analysis flags.

In `internal/controllers/user/partials/user_quick_links.go`, inside `UserQuickLinks`, delete:
- `errorMessage := ""`
- the subsequent `if errorMessage != "" { ... }` block

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._