### PR TITLE
Fix for Duplicate 'if' branches

### DIFF
--- a/internal/controllers/admin/blog/ai_post_content_update/markdown_transform.go
+++ b/internal/controllers/admin/blog/ai_post_content_update/markdown_transform.go
@@ -278,11 +278,7 @@ func writeSection(builder *strings.Builder, title string, paragraphs []string) {
 		sectionTitle = "Section"
 	}
 
-	if builder.Len() > 0 {
-		builder.WriteString("## ")
-	} else {
-		builder.WriteString("## ")
-	}
+	builder.WriteString("## ")
 	builder.WriteString(sectionTitle)
 	builder.WriteString("\n\n")
 


### PR DESCRIPTION
The best fix is to remove the redundant `if/else` and keep one unconditional `builder.WriteString("## ")`, preserving current behavior exactly.

In `internal/controllers/admin/blog/ai_post_content_update/markdown_transform.go`, inside `writeSection` (around lines 281–285), replace the entire conditional block with a single write call:
- Remove:
  - `if builder.Len() > 0 { ... } else { ... }`
- Keep one:
  - `builder.WriteString("## ")`

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._