### PR TITLE
Fix for Arguments redefined

### DIFF
--- a/internal/resources/js/blockarea_v0200.js
+++ b/internal/resources/js/blockarea_v0200.js
@@ -434,8 +434,8 @@ function BlockArea(blockAreaId) {
   };
 
   this.blockAttributes = function () {
-    var arguments = arguments[1];
-    var blockId = arguments.Id;
+    var eventData = arguments[1];
+    var blockId = eventData.Id;
     var block = blocks[_findBlockIndexById(blockId)];
     var blockType = block.Type;
     var blockAttributes = block.Attributes;


### PR DESCRIPTION
The best fix is to stop redefining `arguments` and use a clearly named local variable for the event payload.  
In `internal/resources/js/blockarea_v0200.js`, within `this.blockAttributes`, replace:

- `var arguments = arguments[1];`
- `var blockId = arguments.Id;`

with a non-conflicting variable, e.g. `eventData`:

- `var eventData = arguments[1];`
- `var blockId = eventData.Id;`

This preserves existing behavior (still reading the second argument) while removing the redefinition and improving readability. No imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._