### PR TITLE
Fix for Missing variable declaration

### DIFF
--- a/internal/controllers/admin/blog/ai_post_editor/templates/app.js
+++ b/internal/controllers/admin/blog/ai_post_editor/templates/app.js
@@ -388,7 +388,7 @@ document.addEventListener('DOMContentLoaded', function() {
 async function apiPost(body) {
     body.id = '{{ id }}'
 
-    params = new URLSearchParams(body);
+    const params = new URLSearchParams(body);
     const response = await fetch('{{ url }}', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Declare `params` as a local variable inside `apiPost` where it is created.

Best fix (no functionality change): in `internal/controllers/admin/blog/ai_post_editor/templates/app.js`, update line 391 from implicit assignment to a block-scoped declaration:

- Change `params = new URLSearchParams(body);`
- To `const params = new URLSearchParams(body);`

`const` is appropriate because `params` is not reassigned after creation. No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._