### PR TITLE
Fix for Useless assignment to local variable

### DIFF
--- a/internal/resources/js/blockarea_v0200.js
+++ b/internal/resources/js/blockarea_v0200.js
@@ -253,7 +253,6 @@ function BlockArea(blockAreaId) {
       if (!$ctrl) {
         return; // Not found
       }
-      var type = $ctrl.attr("type");
       var tag = $ctrl.prop("tagName").toLowerCase();
       //console.log(name_key + ":" + value);
       //console.log(tag);


### PR DESCRIPTION
The best fix is to remove the redundant first assignment of `type` (line 256), since it is never used and is always overwritten in the `input` branch. This preserves existing behavior exactly and resolves the CodeQL finding cleanly.

In `internal/resources/js/blockarea_v0200.js`, inside `_formPopulate`:
- Delete `var type = $ctrl.attr("type");` before `tag` is computed.
- Keep the `type` assignment inside `if (tag === "input")` as the only effective assignment used by checkbox/radio logic.

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._