### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/dracory/blueprint/security/code-scanning/1](https://github.com/dracory/blueprint/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/tests.yml` so the workflow does not rely on repository/org defaults.  
Best fix here: define workflow-level permissions right after the `on:` block (before `jobs:`), with the minimum needed scope:

- `contents: read`

This preserves existing functionality (`actions/checkout` and Go build/test) while enforcing least privilege for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
